### PR TITLE
Update CI Node.js version to 24 to match .nvmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install uv


### PR DESCRIPTION
## Summary
- Updates the Node.js version in `.github/workflows/ci.yml` from version 20 to version 24 to match the version specified in `.nvmrc`
- This fixes the inconsistency between local development and CI environments

## Motivation
The `.nvmrc` file specifies Node.js version 24, but the CI workflow was using version 20. This mismatch could lead to differences in behavior between local development and CI, potentially causing issues where code works locally but fails in CI (or vice versa).

## Test plan
- [ ] Verify CI tests pass with Node.js 24
- [ ] Confirm all npm dependencies are compatible with Node.js 24
- [ ] Check that frontend asset building works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)